### PR TITLE
Finishes #166285419 Added authorization tokens to requests

### DIFF
--- a/server/api/controllers/auth.js
+++ b/server/api/controllers/auth.js
@@ -45,11 +45,24 @@ const auth = {
     const data = dbHelper.getUser(id);
 
     // Create a jwt token and send along with the data
-    const payload = { data };
     const options = { expiresIn: '1d' };
-    const secret = process.env.JWT_SECRET;
+    const secret = process.env.JWT_SECRET || 'jwtSecret';
 
-    jwt.sign(payload, secret, options, (err, token) => res.status(201).send({
+    const token = jwt.sign(
+      {
+        data: {
+          id: data.id,
+          firstName: data.firstName,
+          lastName: data.lastName,
+          email: data.email,
+          address: data.address,
+          isAdmin: data.isAdmin,
+        },
+      },
+      secret,
+      options,
+    );
+    return res.status(201).send({
       status: 201,
       data: {
         token,
@@ -60,7 +73,7 @@ const auth = {
         address: data.address,
         isAdmin: data.isAdmin,
       },
-    }));
+    });
   },
 
   /**
@@ -75,11 +88,25 @@ const auth = {
     const data = dbHelper.getUserByEmail(email);
 
     // Create a jwt token and send along with the data
-    const payload = { data };
     const options = { expiresIn: '1d' };
-    const secret = process.env.JWT_SECRET;
+    const secret = process.env.JWT_SECRET || 'jwtSecret';
 
-    jwt.sign(payload, secret, options, (err, token) => res.status(200).send({
+    const token = jwt.sign(
+      {
+        data: {
+          id: data.id,
+          firstName: data.firstName,
+          lastName: data.lastName,
+          email: data.email,
+          address: data.address,
+          isAdmin: data.isAdmin,
+        },
+      },
+      secret,
+      options,
+    );
+
+    return res.status(200).send({
       status: 200,
       data: {
         token,
@@ -90,7 +117,7 @@ const auth = {
         address: data.address,
         isAdmin: data.isAdmin,
       },
-    }));
+    });
   },
 };
 

--- a/server/api/controllers/cars.js
+++ b/server/api/controllers/cars.js
@@ -4,9 +4,7 @@ import dbCarsHelper from '../utils/dbCarsHelper';
 const cars = {
   createAd(req, res) {
     const {
-      owner,
       state,
-      email,
       price,
       manufacturer,
       model,
@@ -18,9 +16,11 @@ const cars = {
     const createdOn = Date.now();
     const status = 'available';
     const id = dummyCars.length + 1;
+    const authData = req.authToken.data;
 
     dbCarsHelper.addCar({
       id,
+      owner: authData.id,
       createdOn,
       manufacturer,
       status,
@@ -29,8 +29,6 @@ const cars = {
       model,
       name,
       bodyType,
-      owner: parseInt(owner, 10),
-      email,
       imageUrlList,
     });
 
@@ -63,7 +61,7 @@ const cars = {
       status: 201,
       data: {
         id: car.id,
-        email: car.email,
+        owner: car.owner,
         created_on: car.createdOn,
         manufacturer: car.manufacturer,
         model: car.model,

--- a/server/api/controllers/purchaseOrders.js
+++ b/server/api/controllers/purchaseOrders.js
@@ -4,10 +4,9 @@ import dbOrdersHelper from '../utils/dbOrdersHelper';
 
 const purchaseOrders = {
   createOrder(req, res) {
-    let { buyer, carId, priceOffered } = req.body;
-
+    let { carId, priceOffered } = req.body;
+    const authData = req.authToken.data;
     carId = parseInt(carId, 10);
-    buyer = parseInt(buyer, 10);
     priceOffered = parseFloat(priceOffered);
 
     const status = 'pending';
@@ -16,8 +15,8 @@ const purchaseOrders = {
 
     dbOrdersHelper.addPurchaseOrder({
       id,
+      buyer: authData.id,
       carId,
-      buyer,
       priceOffered,
       createdOn,
       status,
@@ -28,6 +27,7 @@ const purchaseOrders = {
       status: 201,
       data: {
         id,
+        buyer: authData.id,
         car_id: parseInt(carId, 10),
         created_on: createdOn,
         status,

--- a/server/api/middlewares/carsValidator.js
+++ b/server/api/middlewares/carsValidator.js
@@ -40,33 +40,13 @@ const carsValidator = {
 
       const imgFiles = req.files;
       const {
-        owner,
         state,
         price,
         manufacturer,
         model,
         bodyType,
         name,
-        email,
       } = req.body;
-      if (owner === undefined || owner.trim() === '') {
-        return res.status(400).send({
-          status: 400,
-          error: 'owner undefined or invalid',
-        });
-      }
-      if (!validator.isNumeric(owner)) {
-        return res.status(400).send({
-          status: 400,
-          error: 'owner is not a number',
-        });
-      }
-      if (email === undefined || email.trim() === '' || !validator.isEmail(email)) {
-        return res.status(400).send({
-          status: 400,
-          error: 'email is not valid',
-        });
-      }
       if (state === undefined || state.trim() === '') {
         return res.status(400).send({
           status: 400,
@@ -142,18 +122,12 @@ const carsValidator = {
   },
   markAsSold(req, res, next) {
     const carId = req.params.car_id;
-    const { user } = req.body;
+    const authData = req.authToken;
+    let user;
+    if (authData.id === undefined) {
+      user = authData.data.id;
+    } else { user = authData.id; }
 
-    if (
-      user === undefined
-      || user.trim() === ''
-      || !validator.isNumeric(user)
-    ) {
-      return res.status(400).send({
-        status: 400,
-        error: 'user is required',
-      });
-    }
     if (
       carId === undefined
       || carId.trim() === ''
@@ -172,8 +146,7 @@ const carsValidator = {
         error: 'car advert does not exist',
       });
     }
-
-    if (findCar.owner !== parseInt(user, 10)) {
+    if (findCar.owner !== user) {
       return res.status(403).send({
         status: 403,
         error: "you cannot edit another user's advert",
@@ -191,18 +164,21 @@ const carsValidator = {
   },
   updateCarPrice(req, res, next) {
     const { newPrice } = req.body;
+
     if (
       newPrice === undefined
       || newPrice.trim() === ''
       || !validator.isNumeric(newPrice)
     ) {
-      return res.status(400).send({
+      res.status(400).send({
         status: 400,
         error: 'newPrice is undefined or invalid',
       });
+      return;
     }
-    return next();
+    next();
   },
+
   getUserCar(req, res, next) {
     const carId = req.params.car_id;
     if (

--- a/server/api/middlewares/purchaseOrdersValidator.js
+++ b/server/api/middlewares/purchaseOrdersValidator.js
@@ -6,32 +6,23 @@
 import validator from 'validator';
 import dbCarsHelper from '../utils/dbCarsHelper';
 import dbOrdersHelper from '../utils/dbOrdersHelper';
-import dbHelper from '../utils/dbHelper';
-
 
 const purchaseOrdersValidator = {
   createPurchaseOrder(req, res, next) {
-    const { buyer, carId, priceOffered } = req.body;
+    const { carId, priceOffered } = req.body;
+    const authData = req.authToken.data;
+    const buyer = authData.id;
 
-    if (
-      buyer === undefined
-      || buyer.trim() === ''
-      || !validator.isNumeric(buyer)
-    ) {
-      return res.status(400).send({
-        status: 400,
-        error: 'buyer id is undefined or invalid',
-      });
-    }
     if (
       carId === undefined
       || carId.trim() === ''
       || !validator.isNumeric(carId)
     ) {
-      return res.status(400).send({
+      res.status(400).send({
         status: 400,
         error: 'car id is undefined or invalid',
       });
+      return;
     }
 
     if (
@@ -39,65 +30,54 @@ const purchaseOrdersValidator = {
       || priceOffered.trim() === ''
       || !validator.isNumeric(priceOffered)
     ) {
-      return res.status(400).send({
+      res.status(400).send({
         status: 400,
         error: 'price is undefined or invalid',
       });
+      return;
     }
 
     const findCar = dbCarsHelper.getCar(parseInt(carId, 10));
-    const findBuyer = dbHelper.getUser(parseInt(buyer, 10));
 
-    if (findBuyer === -1) {
-      return res.status(404).send({
-        status: 404,
-        error: 'buyer does not exist',
-      });
-    }
-
-    if (findCar.owner === parseInt(buyer, 10)) {
-      return res.status(409).send({
+    if (findCar.owner === buyer) {
+      res.status(409).send({
         status: 409,
         error: 'you cannot create purchase order for ad you created',
       });
+      return;
     }
     if (findCar === -1) {
-      return res.status(404).send({
+      res.status(404).send({
         status: 404,
         error: 'car not found',
       });
+      return;
     }
 
     if (findCar.status !== 'available') {
-      return res.status(403).send({
+      res.status(403).send({
         status: 403,
         error: 'car has already been sold',
       });
+      return;
     }
 
-    const purchaseOrder = dbOrdersHelper.getOrderByBuyer(parseInt(buyer, 10));
+    const purchaseOrder = dbOrdersHelper.getOrderByBuyer(buyer);
     if (purchaseOrder !== -1) {
-      return res.status(409).send({
+      res.status(409).send({
         status: 409,
         error: 'you already created a purchase order',
       });
+      return;
     }
-    return next();
+    next();
   },
   updatePurchaseOrder(req, res, next) {
     const orderId = req.params.order_id;
-    const { buyer, newPrice } = req.body;
+    const authData = req.authToken.data;
+    const buyer = authData.id;
+    const { newPrice } = req.body;
 
-    if (
-      buyer === undefined
-      || buyer.trim() === ''
-      || !validator.isNumeric(buyer)
-    ) {
-      return res.status(400).send({
-        status: 400,
-        error: 'buyer id is undefined or invalid',
-      });
-    }
     if (
       orderId === undefined
       || orderId.trim() === ''
@@ -123,7 +103,6 @@ const purchaseOrdersValidator = {
     const findOrder = dbOrdersHelper.getOrder(
       parseInt(orderId, 10),
     );
-
     if (findOrder === -1) {
       return res.status(404).send({
         status: 404,
@@ -131,7 +110,7 @@ const purchaseOrdersValidator = {
       });
     }
 
-    if (findOrder.buyer !== parseInt(buyer, 10)) {
+    if (findOrder.buyer !== buyer) {
       return res.status(403).send({
         status: 403,
         error: 'you cannot edit another user\'s order',

--- a/server/api/routes/carsRouter.js
+++ b/server/api/routes/carsRouter.js
@@ -37,4 +37,5 @@ carsRouter.get(
   cars.getUserCar,
 );
 
+
 export default carsRouter;

--- a/server/api/routes/index.js
+++ b/server/api/routes/index.js
@@ -4,6 +4,7 @@ import authRouter from './authRouter';
 import carsRouter from './carsRouter';
 import ordersRouter from './ordersRouter';
 
+
 const route = express.Router();
 
 route.use(bodyParser.json());

--- a/test/car.test.js
+++ b/test/car.test.js
@@ -50,326 +50,6 @@ describe('Users car endpoint test', () => {
   });
 
   describe('route POST /api/v1/car', () => {
-    it('should raise 400 error with no attached file', (done) => {
-      chai
-        .request(app)
-        .post('/api/v1/car')
-        .set('Authorization', 'Bearer d432dd24')
-        .type('form')
-        .field('owner', mockCars.validOwner)
-        .field('state', mockCars.validState)
-        .field('price', mockCars.validPrice)
-        .field('model', mockCars.validModel)
-        .field('manufacturer', mockCars.validManufacturer)
-        .field('bodyType', mockCars.validBodyType)
-        .field('name', mockCars.validName)
-        .field('email', mockCars.validEmail)
-        .end((err, res) => {
-          expect(res).to.have.status(400);
-          const { error } = res.body;
-          assert.strictEqual(
-            error,
-            'please add between 1 and 6 images',
-            'correct number of images should be added',
-          );
-          done();
-        });
-    });
-
-    it('should raise 400 error with no or invalid owner', (done) => {
-      chai
-        .request(app)
-        .post('/api/v1/car')
-        .set('Authorization', 'Bearer d432dd24')
-        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
-        .type('form')
-        .field('state', mockCars.validState)
-        .field('price', mockCars.validPrice)
-        .field('model', mockCars.validModel)
-        .field('manufacturer', mockCars.validManufacturer)
-        .field('bodyType', mockCars.validBodyType)
-        .field('name', mockCars.validName)
-        .field('email', mockCars.validEmail)
-        .end((err, res) => {
-          expect(res).to.have.status(400);
-
-          const { error } = res.body;
-          assert.strictEqual(
-            error,
-            'owner undefined or invalid',
-            'The owner should be valid',
-          );
-          done();
-        });
-    });
-
-    it('should raise 400 error with no attached state', (done) => {
-      chai
-        .request(app)
-        .post('/api/v1/car')
-        .set('Authorization', 'Bearer d432dd24')
-        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
-        .type('form')
-        .field('owner', mockCars.validOwner)
-        .field('price', mockCars.validPrice)
-        .field('model', mockCars.validModel)
-        .field('manufacturer', mockCars.validManufacturer)
-        .field('bodyType', mockCars.validBodyType)
-        .field('name', mockCars.validName)
-        .field('email', mockCars.validEmail)
-        .end((err, res) => {
-          expect(res).to.have.status(400);
-
-          const { error } = res.body;
-          assert.strictEqual(
-            error,
-            'vehicle state is undefined',
-            'vehicle state was not defined',
-          );
-
-          done();
-        });
-    });
-
-    it('should raise 400 error with an invalid state', (done) => {
-      chai
-        .request(app)
-        .post('/api/v1/car')
-        .set('Authorization', 'Bearer d432dd24')
-        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
-        .type('form')
-        .field('owner', mockCars.validOwner)
-        .field('price', mockCars.validPrice)
-        .field('model', mockCars.validModel)
-        .field('state', mockCars.invalidState)
-        .field('manufacturer', mockCars.validManufacturer)
-        .field('bodyType', mockCars.validBodyType)
-        .field('name', mockCars.validName)
-        .field('email', mockCars.validEmail)
-        .end((err, res) => {
-          expect(res).to.have.status(400);
-
-          const { error } = res.body;
-          assert.strictEqual(
-            error,
-            'vehicle state can only be new or used',
-            'vehicle state can only be new or used',
-          );
-
-          done();
-        });
-    });
-
-    it('should raise 400 error with no  price', (done) => {
-      chai
-        .request(app)
-        .post('/api/v1/car')
-        .set('Authorization', 'Bearer d432dd24')
-        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
-        .type('form')
-        .field('owner', mockCars.validOwner)
-        .field('state', mockCars.validState)
-        .field('model', mockCars.validModel)
-        .field('manufacturer', mockCars.validManufacturer)
-        .field('bodyType', mockCars.validBodyType)
-        .field('name', mockCars.validName)
-        .field('email', mockCars.validEmail)
-        .end((err, res) => {
-          expect(res).to.have.status(400);
-
-          done();
-        });
-    });
-
-    it('should raise 400 error with undefined price', (done) => {
-      chai
-        .request(app)
-        .post('/api/v1/car')
-        .set('Authorization', 'Bearer d432dd24')
-        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
-        .type('form')
-        .field('owner', mockCars.validOwner)
-        .field('state', mockCars.validState)
-        .field('model', mockCars.validModel)
-        .field('manufacturer', mockCars.validManufacturer)
-        .field('bodyType', mockCars.validBodyType)
-        .field('name', mockCars.validName)
-        .field('email', mockCars.validEmail)
-        .end((err, res) => {
-          expect(res).to.have.status(400);
-
-          const { error } = res.body;
-          assert.strictEqual(
-            error,
-            'price is undefined',
-            'price is undefined',
-          );
-
-          done();
-        });
-    });
-
-    it('should raise 400 error with invalid price', (done) => {
-      chai
-        .request(app)
-        .post('/api/v1/car')
-        .set('Authorization', 'Bearer d432dd24')
-        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
-        .type('form')
-        .field('owner', mockCars.validOwner)
-        .field('state', mockCars.validState)
-        .field('price', mockCars.invalidPrice)
-        .field('model', mockCars.validModel)
-        .field('manufacturer', mockCars.validManufacturer)
-        .field('bodyType', mockCars.validBodyType)
-        .field('name', mockCars.validName)
-        .field('email', mockCars.validEmail)
-        .end((err, res) => {
-          expect(res).to.have.status(400);
-
-          const { error } = res.body;
-          assert.strictEqual(
-            error,
-            'price is not a number',
-            'price is not a number',
-          );
-
-          done();
-        });
-    });
-
-    it('should raise 400 error with invalid or no model', (done) => {
-      chai
-        .request(app)
-        .post('/api/v1/car')
-        .set('Authorization', 'Bearer d432dd24')
-        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
-        .type('form')
-        .field('owner', mockCars.validOwner)
-        .field('state', mockCars.validState)
-        .field('price', mockCars.validPrice)
-        .field('manufacturer', mockCars.validManufacturer)
-        .field('bodyType', mockCars.validBodyType)
-        .field('name', mockCars.validName)
-        .field('email', mockCars.validEmail)
-        .end((err, res) => {
-          expect(res).to.have.status(400);
-
-          const { error } = res.body;
-          assert.strictEqual(
-            error,
-            'model undefined or invalid',
-            'model undefined or invalid',
-          );
-
-          done();
-        });
-    });
-    it('should raise 400 error with invalid or no manufacturer', (done) => {
-      chai
-        .request(app)
-        .post('/api/v1/car')
-        .set('Authorization', 'Bearer d432dd24')
-        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
-        .type('form')
-        .field('owner', mockCars.validOwner)
-        .field('state', mockCars.validState)
-        .field('price', mockCars.validPrice)
-        .field('model', mockCars.validModel)
-        .field('bodyType', mockCars.validBodyType)
-        .field('name', mockCars.validName)
-        .field('email', mockCars.validEmail)
-        .end((err, res) => {
-          expect(res).to.have.status(400);
-
-          const { error } = res.body;
-          assert.strictEqual(
-            error,
-            'manufacturer is undefined or invalid',
-            'manufacturer is undefined or invalid',
-          );
-
-
-          done();
-        });
-    });
-    it('should raise 400 error with invalid or no body type', (done) => {
-      chai
-        .request(app)
-        .post('/api/v1/car')
-        .set('Authorization', 'Bearer d432dd24')
-        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
-        .type('form')
-        .field('owner', mockCars.validOwner)
-        .field('state', mockCars.validState)
-        .field('price', mockCars.validPrice)
-        .field('model', mockCars.validModel)
-        .field('manufacturer', mockCars.validManufacturer)
-        .field('name', mockCars.validName)
-        .field('email', mockCars.validEmail)
-        .end((err, res) => {
-          expect(res).to.have.status(400);
-
-          const { error } = res.body;
-          assert.strictEqual(
-            error,
-            'body type is undefined or invalid',
-            'body type is undefined or invalid',
-          );
-          done();
-        });
-    });
-    it('should raise 400 error with no or invalid vehicle name', (done) => {
-      chai
-        .request(app)
-        .post('/api/v1/car')
-        .set('Authorization', 'Bearer d432dd24')
-        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
-        .type('form')
-        .field('owner', mockCars.validOwner)
-        .field('state', mockCars.validState)
-        .field('price', mockCars.validPrice)
-        .field('model', mockCars.validModel)
-        .field('manufacturer', mockCars.validManufacturer)
-        .field('bodyType', mockCars.validBodyType)
-        .field('email', mockCars.validEmail)
-        .end((err, res) => {
-          expect(res).to.have.status(400);
-          const { error } = res.body;
-          assert.strictEqual(
-            error,
-            'vehicle name undefined or invalid',
-            'vehicle name undefined or invalid',
-          );
-          done();
-        });
-    });
-    it('should raise 400 error with invalid or no email', (done) => {
-      chai
-        .request(app)
-        .post('/api/v1/car')
-        .set('Authorization', 'Bearer d432dd24')
-        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
-        .type('form')
-        .field('owner', mockCars.validOwner)
-        .field('state', mockCars.validState)
-        .field('price', mockCars.validPrice)
-        .field('model', mockCars.validModel)
-        .field('manufacturer', mockCars.validManufacturer)
-        .field('bodyType', mockCars.validBodyType)
-        .field('name', mockCars.validName)
-        .end((err, res) => {
-          expect(res).to.have.status(400);
-
-          const { error } = res.body;
-          assert.strictEqual(
-            error,
-            'email is not valid',
-            'email is not valid',
-          );
-          done();
-        });
-    });
     it('should raise 401 when authorization token not provided', (done) => {
       chai
         .request(app)
@@ -398,14 +78,14 @@ describe('Users car endpoint test', () => {
           done();
         });
     });
-    it('should raise 201 and successfully create the ad', (done) => {
+    it('should raise 401 with invalid authorization token', (done) => {
       chai
         .request(app)
         .post('/api/v1/car')
-        .set('Authorization', 'Bearer d432dd24')
+        .set('Authorization', 'Bearer adsfljewos')
         .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
         .type('form')
-        .field('owner', mockCars.validOwner)
+        .field('owner', user1.id)
         .field('state', mockCars.validState)
         .field('price', mockCars.validPrice)
         .field('model', mockCars.validModel)
@@ -413,6 +93,279 @@ describe('Users car endpoint test', () => {
         .field('bodyType', mockCars.validBodyType)
         .field('name', mockCars.validName)
         .field('email', mockCars.validEmail)
+        .end((err, res) => {
+          expect(res).to.have.status(401);
+          expect(res.body).to.have.property('status');
+          expect(res.body).to.have.property('error');
+
+          const { error } = res.body;
+          assert.strictEqual(
+            error,
+            'user not authenticated, invalid authorization token provided',
+            'user not authenticated, invalid authorization token provided',
+          );
+          done();
+        });
+    });
+    it('should raise 400 error with no attached file', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/car')
+        .set('Authorization', `Bearer ${user1.token}`)
+        .type('form')
+        .field('state', mockCars.validState)
+        .field('price', mockCars.validPrice)
+        .field('model', mockCars.validModel)
+        .field('manufacturer', mockCars.validManufacturer)
+        .field('bodyType', mockCars.validBodyType)
+        .field('name', mockCars.validName)
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+          const { error } = res.body;
+          assert.strictEqual(
+            error,
+            'please add between 1 and 6 images',
+            'correct number of images should be added',
+          );
+          done();
+        });
+    });
+
+    it('should raise 400 error with no attached state', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/car')
+        .set('Authorization', `Bearer ${user1.token}`)
+        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
+        .type('form')
+        .field('price', mockCars.validPrice)
+        .field('model', mockCars.validModel)
+        .field('manufacturer', mockCars.validManufacturer)
+        .field('bodyType', mockCars.validBodyType)
+        .field('name', mockCars.validName)
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+
+          const { error } = res.body;
+          assert.strictEqual(
+            error,
+            'vehicle state is undefined',
+            'vehicle state was not defined',
+          );
+
+          done();
+        });
+    });
+
+    it('should raise 400 error with an invalid state', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/car')
+        .set('Authorization', `Bearer ${user1.token}`)
+        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
+        .type('form')
+        .field('price', mockCars.validPrice)
+        .field('model', mockCars.validModel)
+        .field('state', mockCars.invalidState)
+        .field('manufacturer', mockCars.validManufacturer)
+        .field('bodyType', mockCars.validBodyType)
+        .field('name', mockCars.validName)
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+
+          const { error } = res.body;
+          assert.strictEqual(
+            error,
+            'vehicle state can only be new or used',
+            'vehicle state can only be new or used',
+          );
+
+          done();
+        });
+    });
+
+    it('should raise 400 error with no  price', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/car')
+        .set('Authorization', `Bearer ${user1.token}`)
+        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
+        .type('form')
+        .field('state', mockCars.validState)
+        .field('model', mockCars.validModel)
+        .field('manufacturer', mockCars.validManufacturer)
+        .field('bodyType', mockCars.validBodyType)
+        .field('name', mockCars.validName)
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+
+          done();
+        });
+    });
+
+    it('should raise 400 error with undefined price', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/car')
+        .set('Authorization', `Bearer ${user1.token}`)
+        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
+        .type('form')
+        .field('state', mockCars.validState)
+        .field('model', mockCars.validModel)
+        .field('manufacturer', mockCars.validManufacturer)
+        .field('bodyType', mockCars.validBodyType)
+        .field('name', mockCars.validName)
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+
+          const { error } = res.body;
+          assert.strictEqual(
+            error,
+            'price is undefined',
+            'price is undefined',
+          );
+
+          done();
+        });
+    });
+
+    it('should raise 400 error with invalid price', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/car')
+        .set('Authorization', `Bearer ${user1.token}`)
+        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
+        .type('form')
+        .field('state', mockCars.validState)
+        .field('price', mockCars.invalidPrice)
+        .field('model', mockCars.validModel)
+        .field('manufacturer', mockCars.validManufacturer)
+        .field('bodyType', mockCars.validBodyType)
+        .field('name', mockCars.validName)
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+
+          const { error } = res.body;
+          assert.strictEqual(
+            error,
+            'price is not a number',
+            'price is not a number',
+          );
+
+          done();
+        });
+    });
+
+    it('should raise 400 error with invalid or no model', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/car')
+        .set('Authorization', `Bearer ${user1.token}`)
+        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
+        .type('form')
+        .field('state', mockCars.validState)
+        .field('price', mockCars.validPrice)
+        .field('manufacturer', mockCars.validManufacturer)
+        .field('bodyType', mockCars.validBodyType)
+        .field('name', mockCars.validName)
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+
+          const { error } = res.body;
+          assert.strictEqual(
+            error,
+            'model undefined or invalid',
+            'model undefined or invalid',
+          );
+
+          done();
+        });
+    });
+    it('should raise 400 error with invalid or no manufacturer', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/car')
+        .set('Authorization', `Bearer ${user1.token}`)
+        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
+        .type('form')
+        .field('state', mockCars.validState)
+        .field('price', mockCars.validPrice)
+        .field('model', mockCars.validModel)
+        .field('bodyType', mockCars.validBodyType)
+        .field('name', mockCars.validName)
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+
+          const { error } = res.body;
+          assert.strictEqual(
+            error,
+            'manufacturer is undefined or invalid',
+            'manufacturer is undefined or invalid',
+          );
+
+          done();
+        });
+    });
+    it('should raise 400 error with invalid or no body type', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/car')
+        .set('Authorization', `Bearer ${user1.token}`)
+        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
+        .type('form')
+        .field('state', mockCars.validState)
+        .field('price', mockCars.validPrice)
+        .field('model', mockCars.validModel)
+        .field('manufacturer', mockCars.validManufacturer)
+        .field('name', mockCars.validName)
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+
+          const { error } = res.body;
+          assert.strictEqual(
+            error,
+            'body type is undefined or invalid',
+            'body type is undefined or invalid',
+          );
+          done();
+        });
+    });
+    it('should raise 400 error with no or invalid vehicle name', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/car')
+        .set('Authorization', `Bearer ${user1.token}`)
+        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
+        .type('form')
+        .field('state', mockCars.validState)
+        .field('price', mockCars.validPrice)
+        .field('model', mockCars.validModel)
+        .field('manufacturer', mockCars.validManufacturer)
+        .field('bodyType', mockCars.validBodyType)
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+          const { error } = res.body;
+          assert.strictEqual(
+            error,
+            'vehicle name undefined or invalid',
+            'vehicle name undefined or invalid',
+          );
+          done();
+        });
+    });
+    it('should raise 201 and successfully create the ad', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/car')
+        .set('Authorization', `Bearer ${user1.token}`)
+        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
+        .type('form')
+        .field('state', mockCars.validState)
+        .field('price', mockCars.validPrice)
+        .field('model', mockCars.validModel)
+        .field('manufacturer', mockCars.validManufacturer)
+        .field('bodyType', mockCars.validBodyType)
+        .field('name', mockCars.validName)
         .end((err, res) => {
           expect(res).to.have.status(201);
           expect(res.body).to.have.property('status');
@@ -426,14 +379,9 @@ describe('Users car endpoint test', () => {
           expect(data).to.have.property('state');
 
           const {
-            email, manufacturer, model, price,
+            manufacturer, model, price,
           } = data;
 
-          assert.strictEqual(
-            email,
-            mockCars.validEmail,
-            'email is not valid',
-          );
           assert.strictEqual(
             manufacturer,
             mockCars.validManufacturer,
@@ -462,54 +410,26 @@ describe('Users car endpoint test', () => {
       chai
         .request(app)
         .post('/api/v1/car')
-        .set('Authorization', 'Bearer d432dd24')
+        .set('Authorization', `Bearer ${user1.token}`)
         .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
         .type('form')
-        .field('owner', user1.id)
         .field('state', mockCars.validState)
         .field('price', mockCars.validPrice)
         .field('model', mockCars.validModel)
         .field('manufacturer', mockCars.validManufacturer)
         .field('bodyType', mockCars.validBodyType)
         .field('name', mockCars.validName)
-        .field('email', user1.email)
         .end(() => {
           done();
         });
     });
-
-    it('should raise 400 error user is undefined', (done) => {
-      chai
-        .request(app)
-        .patch('/api/v1/car/1/status')
-        .set('Authorization', 'Bearer d432dd24')
-        .type('form')
-        .send({
-        })
-        .end((err, res) => {
-          expect(res).to.have.status(400);
-          assert.strictEqual(
-            res.body.status,
-            400,
-            'Status code should be 400',
-          );
-          assert.strictEqual(
-            res.body.error,
-            'user is required',
-            'user is required',
-          );
-          done();
-        });
-    });
-    it('should raise 400 error when carId is undefined', (done) => {
+    it('should raise 400 error when carId is invalid', (done) => {
       chai
         .request(app)
         .patch('/api/v1/car/1as/status')
-        .set('Authorization', 'Bearer d432dd24')
+        .set('Authorization', `Bearer ${user1.token}`)
         .type('form')
-        .send({
-          user: user2.id,
-        })
+        .send()
         .end((err, res) => {
           expect(res).to.have.status(400);
           assert.strictEqual(
@@ -529,11 +449,9 @@ describe('Users car endpoint test', () => {
       chai
         .request(app)
         .patch('/api/v1/car/2/status')
-        .set('Authorization', 'Bearer d432dd24')
+        .set('Authorization', `Bearer ${user1.token}`)
         .type('form')
-        .send({
-          user: user2.id,
-        })
+        .send()
         .end((err, res) => {
           expect(res).to.have.status(404);
           assert.strictEqual(
@@ -553,11 +471,9 @@ describe('Users car endpoint test', () => {
       chai
         .request(app)
         .patch('/api/v1/car/1/status')
-        .set('Authorization', 'Bearer d432dd24')
+        .set('Authorization', `Bearer ${user2.token}`)
         .type('form')
-        .send({
-          user: user2.id,
-        })
+        .send()
         .end((err, res) => {
           expect(res).to.have.status(403);
           assert.strictEqual(
@@ -577,19 +493,13 @@ describe('Users car endpoint test', () => {
       chai
         .request(app)
         .patch('/api/v1/car/1/status')
-        .set('Authorization', 'Bearer d432dd24')
+        .set('Authorization', `Bearer ${user1.token}`)
         .type('form')
-        .send({
-          user: user1.id,
-        })
+        .send()
         .end((err, res) => {
           expect(res).to.have.status(201);
           const { status, data } = res.body;
-          assert.strictEqual(
-            status,
-            201,
-            'Status code should be 201',
-          );
+          assert.strictEqual(status, 201, 'Status code should be 201');
           assert.strictEqual(
             data.status,
             'sold',
@@ -602,11 +512,9 @@ describe('Users car endpoint test', () => {
       chai
         .request(app)
         .patch('/api/v1/car/1/status')
-        .set('Authorization', 'Bearer d432dd24')
+        .set('Authorization', `Bearer ${user1.token}`)
         .type('form')
-        .send({
-          user: user1.id,
-        })
+        .send()
         .end((err, res) => {
           expect(res).to.have.status(409);
           const { error } = res.body;
@@ -630,28 +538,26 @@ describe('Users car endpoint test', () => {
       chai
         .request(app)
         .post('/api/v1/car')
-        .set('Authorization', 'Bearer d432dd24')
+        .set('Authorization', `Bearer ${user1.token}`)
         .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
         .type('form')
-        .field('owner', user1.id)
         .field('state', mockCars.validState)
         .field('price', mockCars.validPrice)
         .field('model', mockCars.validModel)
         .field('manufacturer', mockCars.validManufacturer)
         .field('bodyType', mockCars.validBodyType)
         .field('name', mockCars.validName)
-        .field('email', user1.email)
-        .end(() => { done(); });
+        .end(() => {
+          done();
+        });
     });
     it('should raise 400 error newPrice is undefined', (done) => {
       chai
         .request(app)
         .patch('/api/v1/car/1/price')
-        .set('Authorization', 'Bearer d432dd24')
+        .set('Authorization', `Bearer ${user1.token}`)
         .type('form')
-        .send({
-          user: user1.id,
-        })
+        .send()
         .end((err, res) => {
           expect(res).to.have.status(400);
           assert.strictEqual(
@@ -671,10 +577,9 @@ describe('Users car endpoint test', () => {
       chai
         .request(app)
         .patch('/api/v1/car/1/price')
-        .set('Authorization', 'Bearer d432dd24')
+        .set('Authorization', `Bearer ${user1.token}`)
         .type('form')
         .send({
-          user: user1.id,
           newPrice: '1200000',
         })
         .end((err, res) => {
@@ -695,17 +600,15 @@ describe('Users car endpoint test', () => {
       chai
         .request(app)
         .post('/api/v1/car')
-        .set('Authorization', 'Bearer d432dd24')
+        .set('Authorization', `Bearer ${user1.token}`)
         .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
         .type('form')
-        .field('owner', user1.id)
         .field('state', mockCars.validState)
         .field('price', mockCars.validPrice)
         .field('model', mockCars.validModel)
         .field('manufacturer', mockCars.validManufacturer)
         .field('bodyType', mockCars.validBodyType)
         .field('name', mockCars.validName)
-        .field('email', user1.email)
         .end(() => {
           done();
         });
@@ -714,7 +617,6 @@ describe('Users car endpoint test', () => {
       chai
         .request(app)
         .get('/api/v1/car/1s')
-        .set('Authorization', 'Bearer d432dd24')
         .type('form')
         .send()
         .end((err, res) => {
@@ -736,7 +638,6 @@ describe('Users car endpoint test', () => {
       chai
         .request(app)
         .get('/api/v1/car/2')
-        .set('Authorization', 'Bearer d432dd24')
         .type('form')
         .send()
         .end((err, res) => {
@@ -758,9 +659,8 @@ describe('Users car endpoint test', () => {
       chai
         .request(app)
         .get('/api/v1/car/1')
-        .set('Authorization', 'Bearer d432dd24')
         .type('form')
-        .send({})
+        .send()
         .end((err, res) => {
           const { data, status } = res.body;
           expect(res).to.have.status(200);
@@ -769,7 +669,6 @@ describe('Users car endpoint test', () => {
           expect(data).to.have.property('created_on');
           expect(data).to.have.property('status');
           expect(data).to.have.property('price');
-          expect(data).to.have.property('email');
           expect(data).to.have.property('model');
           expect(data).to.have.property('state');
           expect(data).to.have.property('image_url_list');


### PR DESCRIPTION
#### What does this PR do?
Added JWT Authorization token to all requests

#### Description of Task to be completed?
The tests used dummy tokens when requests were being sent.
This means user data was sent through the form body, and not the token payload
A revamp was made to make sure protected endpoints use **valid** tokens and the data, formally gotten from the form body was now removed and the JWT payload is now being used instead
Unit tests were refactored to adhere to this new development.

#### How should this be manually tested?
After cloning the repo

Start the development server with
npm run dev
After signing in, and you want to access a protected route,
Copy your Authorization token, 
On postman, set the Authorization header of the route you want to access with the value of your token
Bearer <token>
The form body should contain the necessary fields

#### Any background context you want to provide?
Developments and test environments now require a valid authorization token to access protected endpoints

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/166285419