### PR TITLE
#166796380 Sellers can accept or reject orders

### DIFF
--- a/server/api/config/pool.js
+++ b/server/api/config/pool.js
@@ -38,10 +38,13 @@ export const query = async (queryText) => {
    * @param {array} queries - Array of query strings
    */
 export const transaction = async (...queries) => {
+  // update to return values from all query
+  const returnQueries = [];
   try {
     await pool.query('BEGIN');
     for (let i = 0; i < queries.length; i += 1) {
-      await pool.query(queries[i]);
+      const res = await pool.query(queries[i]);
+      returnQueries.push(res);
     }
     await pool.query('COMMIT');
   } catch (err) {
@@ -52,5 +55,6 @@ export const transaction = async (...queries) => {
       `error occured performing db transaction \n error details: \n ${err.stack}`,
     );
   }
+  return returnQueries;
 };
 export default pool;

--- a/server/api/controllers/Cars.js
+++ b/server/api/controllers/Cars.js
@@ -137,18 +137,18 @@ class Cars {
   }
 
   /**
-   * @method getAvailableCar
-   * @description - Fetches a specific available car
+   * @method getCar
+   * @description - Fetches a car
    * @param {object} req - Request object
    * @param {object} res - Response object
    * @returns {object} - JSON Response
    */
-  static async getAvailableCar(req, res) {
+  static async getCar(req, res) {
     let carId = req.params.car_id;
 
     carId = parseInt(carId, 10);
 
-    const queryResult = await carsHelper.getAvailableCar(carId);
+    const queryResult = await carsHelper.getCar(carId);
 
     const data = {
       id: queryResult.id,

--- a/server/api/middlewares/CarsValidator.js
+++ b/server/api/middlewares/CarsValidator.js
@@ -188,13 +188,13 @@ class CarsValidator {
   }
 
   /**
-   * @method getAvailableCar
-   * @description - validates available car parameter
+   * @method getCar
+   * @description - validates get car parameter
    * @param {object} req - Request object
    * @param {object} res - Response object
    * @param {function} next - Passes control to next middleware
    */
-  static async getAvailableCar(req, res, next) {
+  static async getCar(req, res, next) {
     const carId = req.params.car_id;
 
     if (carId.trim() === '' || !validator.isNumeric(carId)) {
@@ -202,7 +202,7 @@ class CarsValidator {
       return;
     }
 
-    const car = await carsHelper.getAvailableCar(parseInt(carId, 10));
+    const car = await carsHelper.getCar(parseInt(carId, 10));
 
     if (car === -1) {
       ResponseHandler.error(res, 404, 'car does not exist');

--- a/server/api/models/carsModel.js
+++ b/server/api/models/carsModel.js
@@ -21,15 +21,6 @@ export const getAllCars = async () => {
   return queryResult.rows;
 };
 
-export const getAvailableCar = async (id) => {
-  const queryText = {
-    name: 'fetch-available-car',
-    text: 'SELECT * FROM cars WHERE id = $1 AND status = $2',
-    values: [id, 'available'],
-  };
-  const queryResult = await query(queryText);
-  return queryResult.rows[0] || -1;
-};
 export const getAvailableCars = async () => {
   const queryText = {
     name: 'fetch-available-cars',

--- a/server/api/models/ordersModel.js
+++ b/server/api/models/ordersModel.js
@@ -11,11 +11,12 @@ export const getOrder = async (id) => {
   return queryResult.rows[0] || -1;
 };
 
-export const getOrderByBuyer = async (buyer) => {
+
+export const getOrderByBuyer = async (buyer, carId) => {
   const queryText = {
     name: 'get-order-buyer',
-    text: 'SELECT * FROM orders WHERE buyer = $1',
-    values: [buyer],
+    text: 'SELECT * FROM orders WHERE buyer = $1 AND car_id = $2',
+    values: [buyer, carId],
   };
   const queryResult = await query(queryText);
 
@@ -25,8 +26,8 @@ export const getOrderByBuyer = async (buyer) => {
 export const editPurchaseOrder = async (id, newPrice) => {
   const queryText = {
     name: 'edit-purchase-order',
-    text: 'UPDATE orders SET price_offered = $1 WHERE id = $2 RETURNING *',
-    values: [newPrice, id],
+    text: 'UPDATE orders SET price_offered = $1, status = $2 WHERE id = $3 RETURNING *',
+    values: [newPrice, 'pending', id],
   };
   const queryResult = await query(queryText);
 

--- a/server/api/routes/carsRouter.js
+++ b/server/api/routes/carsRouter.js
@@ -30,15 +30,15 @@ carsRouter.patch(
 
 carsRouter.get(
   '/:car_id/',
-  CarsValidator.getAvailableCar,
-  Cars.getAvailableCar,
+  CarsValidator.getCar,
+  Cars.getCar,
 );
 
 carsRouter.delete(
   '/:car_id/',
   Authorization.verifyToken,
   Authorization.isAdmin,
-  CarsValidator.getAvailableCar,
+  CarsValidator.getCar,
   Cars.deleteCar,
 );
 

--- a/server/api/routes/ordersRouter.js
+++ b/server/api/routes/ordersRouter.js
@@ -23,4 +23,16 @@ ordersRouter.patch('/:order_id/price',
   PurchaseOrdersValidator.updatePurchaseOrder,
   PurchaseOrders.updatePurchaseOrder);
 
+// // Protected route
+ordersRouter.patch('/:order_id/accept',
+  Authorization.verifyToken,
+  PurchaseOrdersValidator.orderResponse,
+  PurchaseOrders.acceptOrder);
+
+// Protected route
+ordersRouter.patch('/:order_id/reject',
+  Authorization.verifyToken,
+  PurchaseOrdersValidator.orderResponse,
+  PurchaseOrders.rejectOrder);
+
 export default ordersRouter;

--- a/server/api/utils/imageUploader.js
+++ b/server/api/utils/imageUploader.js
@@ -1,5 +1,8 @@
 import faker from 'faker';
+import debug from 'debug';
 import uploader from '../config/cloudinary';
+
+const log = debug('automart');
 
 /**
  * @function imageUploader
@@ -24,7 +27,8 @@ const imageUploader = async (image) => {
       await uploader.destroy(imagePublicId);
     }
   } catch (err) {
-    ({ imageUrl } = faker.image.imageUrl());
+    log(err);
+    imageUrl = faker.image.imageUrl();
   }
 
   return imageUrl;


### PR DESCRIPTION
#### What does this PR do?
Sellers can accept or reject Purchase orders

#### Description of Task to be completed?
The following endpoints should be completed
1. **PATCH /order/<order_id>/accept**
2. **PATCH /order/<order_id>/reject**

#### How should this be manually tested?
- Clone the repo and CD into it
- Install dependencies with `npm install`
- On your machine, create a database named **'auto_mart'** and make sure the user **'postgres'** has full privileges
- Drop all existing tables in the database by running the following command on your Command Line Interface 
```
npm run db:reset
```
- Create tables the database by running the following command on your Command Line Interface 
```
npm run db:migrate
```
- On postman, access the endpoint
```
http://localhost:3000/api/v1/order/<order_id>/accept
http://localhost:3000/api/v1/order/<order_id>/reject
```
- Add the authorization through headers by providing your token
`Authorization: Bearer <token>`

- You can now test the above-specified endpoints on postman if there is an existing purchase order
Check [the documentation](https://mthamayor-auto-mart.herokuapp.com/api/v1/docs) for the endpoints specifications

#### Any background context you want to provide?
Accepting a purchase order automatically marks that advert as sold

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/166796380

#### Screenshots (if appropriate)
None

#### Questions:
None