### PR TITLE
#166813719 Admins can get car flags

### DIFF
--- a/server/api/controllers/Flags.js
+++ b/server/api/controllers/Flags.js
@@ -1,8 +1,5 @@
-import debug from 'debug';
 import { HelperFunctions, ResponseHandler } from '../utils';
 import { query } from '../config/pool';
-
-const log = debug('automart');
 
 /**
  * @class Flags
@@ -33,16 +30,12 @@ class Flags {
         reporter,
         parseInt(carId, 10),
         HelperFunctions.replaceAllWhitespace(reason),
-        HelperFunctions.replaceAllWhitespace(description)],
+        HelperFunctions.replaceAllWhitespace(description),
+      ],
     };
-    let queryResult;
-    try {
-      queryResult = await query(queryText);
-    } catch (err) {
-      log(err.stack);
-      ResponseHandler.error(res, 500, 'internal server error');
-      return;
-    }
+
+    const queryResult = await query(queryText);
+
     const flag = queryResult.rows[0];
 
     const data = {
@@ -54,6 +47,33 @@ class Flags {
     };
 
     ResponseHandler.success(res, 201, data);
+  }
+
+  /**
+   * @method getCarFlags
+   * @description - Flags advert
+   * @param {object} req - Request object
+   * @param {object} res - Response object
+   * @returns {object} - JSON Response
+   */
+  static async getCarFlags(req, res) {
+    const { carId } = parseInt(req.params.car_id, 10);
+
+
+    const queryText = {
+      name: 'select-car-flags',
+      text:
+        'SELECT * FROM flags WHERE car_id = $1 ',
+      values: [
+        carId,
+      ],
+    };
+
+    const queryResult = await query(queryText);
+
+    const data = queryResult.rows;
+
+    ResponseHandler.success(res, 200, data);
   }
 }
 export default Flags;

--- a/server/api/routes/carsRouter.js
+++ b/server/api/routes/carsRouter.js
@@ -4,6 +4,7 @@
 import express from 'express';
 import { Cars } from '../controllers';
 import { Authorization, CarsValidator } from '../middlewares';
+import Flags from '../controllers/Flags';
 
 const carsRouter = express.Router();
 
@@ -46,5 +47,14 @@ carsRouter.get('/',
   Authorization.adminSearch,
   CarsValidator.filterCars,
   Cars.filterCars);
+
+// Admins can view all flags for posted AD
+carsRouter.get(
+  '/:car_id/flags',
+  Authorization.verifyToken,
+  Authorization.isAdmin,
+  CarsValidator.getCar,
+  Flags.getCarFlags,
+);
 
 export default carsRouter;

--- a/test/car.test.js
+++ b/test/car.test.js
@@ -657,6 +657,50 @@ describe('Car endpoint test', () => {
       );
     });
   });
+  describe('route GET car/:car_id/flags', () => {
+    before(async () => {
+      await carsHelper.clearCars();
+    });
+    before(async () => {
+      const res = await chai
+        .request(app)
+        .post('/api/v1/car')
+        .set('Authorization', `Bearer ${user1.token}`)
+        .attach('imageArray', fileUrl, 'toyoto-avalon.jpg')
+        .type('form')
+        .field('state', mockCars.validState)
+        .field('price', mockCars.validPrice)
+        .field('model', mockCars.validModel)
+        .field('manufacturer', mockCars.validManufacturer)
+        .field('bodyType', mockCars.validBodyType)
+        .field('name', mockCars.validName);
+      car1 = res.body.data;
+    });
+    // Make user 1 an admin
+    before(async () => {
+      const res = await chai
+        .request(app)
+        .post(`/api/v1/auth/${user1.id}/admin`)
+        .type('form')
+        .send();
+      user1 = res.body.data;
+    });
+
+    it('should raise 200 when the flags for ad were successfully retrieved', async () => {
+      const res = await chai
+        .request(app)
+        .get(`/api/v1/car/${car1.id}/flags`)
+        .set('Authorization', `Bearer ${user1.token}`)
+        .type('form')
+        .send();
+      expect(res).to.have.status(200);
+      expect(res.body).to.have.property('status');
+      expect(res.body).to.have.property('data');
+      const { data, status } = res.body;
+      expect(data).to.be.a('array');
+      assert.strictEqual(status, 200, 'delete status should be 200');
+    });
+  });
   describe('route DELETE /api/v1/car/:car_id/', () => {
     before(async () => {
       await carsHelper.clearCars();


### PR DESCRIPTION
#### What does this PR do?
Admins can get all flags on an advert

#### Description of Task to be completed?
The following endpoints should be completed
1. **GET car/<car_id>/flags**

#### How should this be manually tested?
- Clone the repo and CD into it
- Install dependencies with `npm install`
- On your machine, create a database named **'auto_mart'** and make sure the user **'postgres'** has full privileges
- Migrate  tables the database by running the following command on your Command Line Interface 
```
npm run db:migrate
```
- On postman, access the endpoint
```
http://localhost:3000/api/v1/car/<car_id>/flags
```
- Add the authorization through headers by providing your token
`Authorization: Bearer <token>`

- You can now test the above-specified endpoints on postman if there is an existing purchase order
Check [the documentation](https://mthamayor-auto-mart.herokuapp.com/api/v1/docs) for the endpoints specifications

#### Any background context you want to provide?
You must be an admin to get all flags on an advert

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/166813719

#### Screenshots (if appropriate)
None

#### Questions:
None