### PR TITLE
bug(flag):fix db always returning empty flags

### DIFF
--- a/server/api/controllers/Flags.js
+++ b/server/api/controllers/Flags.js
@@ -57,7 +57,7 @@ class Flags {
    * @returns {object} - JSON Response
    */
   static async getCarFlags(req, res) {
-    const { carId } = parseInt(req.params.car_id, 10);
+    const carId = parseInt(req.params.car_id, 10);
 
 
     const queryText = {


### PR DESCRIPTION
#### What does this PR do?
Fix GET car/<car_id>/flags always returning empty body

#### Description of Task to be completed?
Remove destructuring on carId variable

#### How should this be manually tested?
None

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/166992145

#### Screenshots (if appropriate)
None

#### Questions:
None